### PR TITLE
fixes lhs/rhs value twist for binary operators

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -341,8 +341,8 @@ namespace Eval {
             Dynamic lhs = call(o.lhs); // be sure to evaluate only once
             Dynamic rhs = call(o.rhs);
 
-            ValueV rhsv = lhs.value();
-            ValueV lhsv = rhs.value();
+            ValueV lhsv = lhs.value();
+            ValueV rhsv = rhs.value();
 
             auto arith = [&](auto op) {
                 return boost::apply_visitor(detail::Arithmetic<decltype(op)>{}, lhsv, rhsv);


### PR DESCRIPTION
i've started the inital integration (after so many month) and found instantly a bug with the binary operator evaluation - i have no idea how that slipped through our intensiv testing, but the rest seems just fine

great source for learning spirit/boost

hope you're fine